### PR TITLE
.travis.yml: Use venv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,12 @@ cache:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get -y install python3-pip python-dev
-  - sudo pip3 install -U pip setuptools virtualenvwrapper
-  - sudo pip3 install -U coala-bears --pre
+  # Install coala to be used by the test suite
+  - sudo apt-get -y install python3.4-venv
+  - python3 -m venv .
+  - source ./bin/activate
+  - pip3 install -U 'pip<10' 'setuptools<22'
+  - pip3 install coala-bears
   - sudo apt-get -y install metacity
 
 script: mvn -X -Dtycho.disableP2Mirrors=true clean verify


### PR DESCRIPTION
Python3.4 apt packages install a colorama that conflicts
with the requirements of coala, and can not be overriden
as it uses distutils and modern pip&setuptools error
when they encounter a distutils package.
Use a fresh venv for installation.

Fixes https://github.com/coala/coala-eclipse/issues/49